### PR TITLE
Fix Herdt's PG final position and running signal

### DIFF
--- a/src/PatternGeneratorInterfacePrivate.cpp
+++ b/src/PatternGeneratorInterfacePrivate.cpp
@@ -1325,8 +1325,8 @@ namespace PatternGeneratorJRL {
 			  m_COMBuffer,
 			  m_LeftFootPositions,
 			  m_RightFootPositions);
-      }
     m_Running = m_ZMPVRQP->Running();
+      }
             
             
     m_GlobalStrategyManager->OneGlobalStepOfControl(LeftFootPosition,

--- a/src/PatternGeneratorInterfacePrivate.cpp
+++ b/src/PatternGeneratorInterfacePrivate.cpp
@@ -164,6 +164,7 @@ namespace PatternGeneratorJRL {
     m_NewTheta = 0.0;
     m_NewStep = false;
     m_ShouldBeRunning = false;
+    m_Running = false;
 
     m_AbsMotionTheta = 0;
     m_InternalClock = 0.0;
@@ -1187,14 +1188,14 @@ namespace PatternGeneratorJRL {
     COMState finalCOMState;
     FootAbsolutePosition LeftFootPosition,RightFootPosition;
 
-    return RunOneStepOfTheControlLoop(CurrentConfiguration,
+    m_Running = RunOneStepOfTheControlLoop(CurrentConfiguration,
 				      CurrentVelocity,
 				      CurrentAcceleration,
 				      ZMPTarget,
 				      finalCOMState,
 				      LeftFootPosition,
 				      RightFootPosition);
-
+    return m_Running;
   }
 
   bool PatternGeneratorInterfacePrivate::RunOneStepOfTheControlLoop(FootAbsolutePosition &LeftFootPosition,
@@ -1207,9 +1208,8 @@ namespace PatternGeneratorJRL {
     MAL_VECTOR_TYPE(double)  CurrentAcceleration;
     MAL_VECTOR( ZMPTarget,double);
     COMState aCOMRefState;
-    bool r=false;
 
-    r = RunOneStepOfTheControlLoop(CurrentConfiguration,
+    m_Running = RunOneStepOfTheControlLoop(CurrentConfiguration,
 				   CurrentVelocity,
 				   CurrentAcceleration,
 				   ZMPTarget,
@@ -1221,7 +1221,7 @@ namespace PatternGeneratorJRL {
     bzero(&ZMPRefPos,sizeof(ZMPPosition));
     ZMPRefPos.px = ZMPTarget(0);
     ZMPRefPos.py = ZMPTarget(1);
-    return r;
+    return m_Running;
   }
 
 
@@ -1233,9 +1233,8 @@ namespace PatternGeneratorJRL {
 								    FootAbsolutePosition &LeftFootPosition,
 								    FootAbsolutePosition &RightFootPosition )
   {
-    bool r=false;
     COMState aCOMState;
-    r=RunOneStepOfTheControlLoop(CurrentConfiguration,
+    m_Running = RunOneStepOfTheControlLoop(CurrentConfiguration,
 			       CurrentVelocity,
 			       CurrentAcceleration,
 			       ZMPTarget,
@@ -1243,7 +1242,7 @@ namespace PatternGeneratorJRL {
 			       LeftFootPosition,
 			       RightFootPosition);
     finalCOMPosition = aCOMState;
-    return r;
+    return m_Running;
   }
 
   bool PatternGeneratorInterfacePrivate::RunOneStepOfTheControlLoop(MAL_VECTOR_TYPE(double) & CurrentConfiguration,
@@ -1268,9 +1267,12 @@ namespace PatternGeneratorJRL {
 	ODEBUG("m_ShouldBeRunning : "<< m_ShouldBeRunning << endl <<
 	       "m_GlobalStrategyManager: " << m_GlobalStrategyManager->EndOfMotion());
 
-	return false;//Andremize
+    m_Running = false;
+	return m_Running;//Andremize
       }
     ODEBUG("Internal clock:" << m_InternalClock);
+
+    m_Running = true;
 
     if (m_StepStackHandler->IsOnLineSteppingOn())
       {
@@ -1324,6 +1326,7 @@ namespace PatternGeneratorJRL {
 			  m_LeftFootPositions,
 			  m_RightFootPositions);
       }
+    m_Running = m_ZMPVRQP->Running();
             
             
     m_GlobalStrategyManager->OneGlobalStepOfControl(LeftFootPosition,
@@ -1509,7 +1512,7 @@ namespace PatternGeneratorJRL {
     // to be done only when the robot has finish a motion.
     UpdateAbsolutePosition(UpdateAbsMotionOrNot);
     ODEBUG("Return true");
-    return true;
+    return m_Running;
   }
 
 

--- a/src/ZMPRefTrajectoryGeneration/ZMPVelocityReferencedQP.cpp
+++ b/src/ZMPRefTrajectoryGeneration/ZMPVelocityReferencedQP.cpp
@@ -58,7 +58,7 @@ ZMPVelocityReferencedQP::ZMPVelocityReferencedQP(SimplePluginManager *SPM,
     ZMPRefTrajectoryGeneration(SPM),
     Robot_(0),SupportFSM_(0),OrientPrw_(0),VRQPGenerator_(0),IntermedData_(0),RFI_(0),Problem_(),Solution_()
 {
-
+  Running_ = false;
   TimeBuffer_ = 0.04;
   QP_T_ = 0.1;
   QP_N_ = 16;
@@ -411,6 +411,7 @@ ZMPVelocityReferencedQP::OnLine(double time,
       {
          double jx = (FinalLeftFootTraj_deq[0].x + FinalRightFootTraj_deq[0].x)/2 - FinalCOMTraj_deq[0].x[0];
          double jy = (FinalLeftFootTraj_deq[0].y + FinalRightFootTraj_deq[0].y)/2 - FinalCOMTraj_deq[0].y[0];
+         if(fabs(jx) < 1e-3 && fabs(jy) < 1e-3) { Running_ = false; }
          const double tf = 0.75;
          jx = 6/(tf*tf*tf)*(jx - tf*FinalCOMTraj_deq[0].x[1] - (tf*tf/2)*FinalCOMTraj_deq[0].x[2]);
          jy = 6/(tf*tf*tf)*(jy - tf*FinalCOMTraj_deq[0].y[1] - (tf*tf/2)*FinalCOMTraj_deq[0].y[2]);
@@ -420,6 +421,7 @@ ZMPVelocityReferencedQP::OnLine(double time,
       }
       else
       {
+         Running_ = true;
          CoM_.Interpolation( FinalCOMTraj_deq, FinalZMPTraj_deq, currentIndex,
              Solution_.Solution_vec[0], Solution_.Solution_vec[QP_N_] );
          CoM_.OneIteration( Solution_.Solution_vec[0],Solution_.Solution_vec[QP_N_] );

--- a/src/ZMPRefTrajectoryGeneration/ZMPVelocityReferencedQP.cpp
+++ b/src/ZMPRefTrajectoryGeneration/ZMPVelocityReferencedQP.cpp
@@ -407,9 +407,23 @@ ZMPVelocityReferencedQP::OnLine(double time,
       unsigned currentIndex = FinalCOMTraj_deq.size();
       FinalCOMTraj_deq.resize( (unsigned)(QP_T_/m_SamplingPeriod)+currentIndex );
       FinalZMPTraj_deq.resize( (unsigned)(QP_T_/m_SamplingPeriod)+currentIndex );
-      CoM_.Interpolation( FinalCOMTraj_deq, FinalZMPTraj_deq, currentIndex,
-          Solution_.Solution_vec[0], Solution_.Solution_vec[QP_N_] );
-      CoM_.OneIteration( Solution_.Solution_vec[0],Solution_.Solution_vec[QP_N_] );
+      if(Solution_.SupportStates_deq.size() &&  Solution_.SupportStates_deq[0].NbStepsLeft == 0)
+      {
+         double jx = (FinalLeftFootTraj_deq[0].x + FinalRightFootTraj_deq[0].x)/2 - FinalCOMTraj_deq[0].x[0];
+         double jy = (FinalLeftFootTraj_deq[0].y + FinalRightFootTraj_deq[0].y)/2 - FinalCOMTraj_deq[0].y[0];
+         const double tf = 0.75;
+         jx = 6/(tf*tf*tf)*(jx - tf*FinalCOMTraj_deq[0].x[1] - (tf*tf/2)*FinalCOMTraj_deq[0].x[2]);
+         jy = 6/(tf*tf*tf)*(jy - tf*FinalCOMTraj_deq[0].y[1] - (tf*tf/2)*FinalCOMTraj_deq[0].y[2]);
+         CoM_.Interpolation( FinalCOMTraj_deq, FinalZMPTraj_deq, currentIndex,
+             jx, jy);
+         CoM_.OneIteration( jx, jy );
+      }
+      else
+      {
+         CoM_.Interpolation( FinalCOMTraj_deq, FinalZMPTraj_deq, currentIndex,
+             Solution_.Solution_vec[0], Solution_.Solution_vec[QP_N_] );
+         CoM_.OneIteration( Solution_.Solution_vec[0],Solution_.Solution_vec[QP_N_] );
+      }
 
 
       // INTERPOLATE TRUNK ORIENTATION:

--- a/src/ZMPRefTrajectoryGeneration/ZMPVelocityReferencedQP.h
+++ b/src/ZMPRefTrajectoryGeneration/ZMPVelocityReferencedQP.h
@@ -113,6 +113,9 @@ namespace PatternGeneratorJRL
       NewVelRef_.Local.Yaw = dyaw;
     }
 
+    inline bool Running()
+    {   return Running_; }
+
     /// \brief Set the final-stage trigger
     inline void EndingPhase(bool EndingPhase)
     { EndingPhase_ = EndingPhase;}
@@ -146,6 +149,9 @@ namespace PatternGeneratorJRL
 
     /// \brief Final stage trigger
     bool EndingPhase_;
+
+    /// \brief PG running
+    bool Running_;
 
     /// \brief Time at which the online mode will stop
     double TimeToStopOnLineMode_;

--- a/src/ZMPRefTrajectoryGeneration/ZMPVelocityReferencedQP.hh
+++ b/src/ZMPRefTrajectoryGeneration/ZMPVelocityReferencedQP.hh
@@ -113,6 +113,9 @@ namespace PatternGeneratorJRL
       NewVelRef_.Local.Yaw = dyaw;
     }
 
+    inline bool Running()
+    { return Running_; }
+
     /// \brief Set the final-stage trigger
     inline void EndingPhase(bool EndingPhase)
     { EndingPhase_ = EndingPhase;}
@@ -146,6 +149,9 @@ namespace PatternGeneratorJRL
 
     /// \brief Final stage trigger
     bool EndingPhase_;
+
+    /// \brief PG running
+    bool Running_;
 
     /// \brief Time at which the online mode will stop
     double TimeToStopOnLineMode_;

--- a/src/patterngeneratorinterfaceprivate.hh
+++ b/src/patterngeneratorinterfaceprivate.hh
@@ -593,6 +593,8 @@ namespace PatternGeneratorJRL
 
     bool m_ShouldBeRunning;
 
+    bool m_Running;
+
     /*! \name To handle a new step. 
       @{
      */


### PR DESCRIPTION
Hello,

These patches change two things:
- "fix" the final position of the CoM, without the patch the robot stops in a crooked position when stopping, this patch ensures that the final position of the CoM is set at the center of the two feet. To do this, we check if the PG still has steps to execute, if not we send the proper acceleration to the CoM.
- Set the running value properly, this is used to compute the 'inprocess' signal that indicates whether or not the PG is still processing data.

Both patches have been well tested on HRP2-10.

Note: I initially wanted to split those two patches (as I am not sure if the first one is the best/proper way to do that) but since the second one relies on the first one it was not possible.
