### PR TITLE
Topic/fix pg initialization

### DIFF
--- a/include/jrl/walkgen/pgtypes.hh
+++ b/include/jrl/walkgen/pgtypes.hh
@@ -61,6 +61,16 @@ namespace PatternGeneratorJRL
 
   };
 
+  inline std::ostream & operator<<(std::ostream & os, const COMPosition_s & aCp)
+  {
+    for(size_t i = 0; i < 3; ++i)
+    {
+      os << "x[" << i << "] " << aCp.x[i] << " y[" << i << "] " << aCp.y[i] << " z[" << i << "] " << aCp.z[i] << std::endl;
+    }
+    os << "yaw " << aCp.yaw << " pitch " << aCp.pitch << " roll " << aCp.roll;
+    return os;
+  }
+
   typedef struct COMPosition_s COMPosition;
   typedef struct COMPosition_s WaistState;
 
@@ -98,6 +108,13 @@ namespace PatternGeneratorJRL
   };
   typedef struct RelativeFootPosition_s RelativeFootPosition;
 
+  inline std::ostream & operator<<(std::ostream & os, const RelativeFootPosition_s & rfp)
+  {
+    os << "sx " << rfp.sx << " sy " << rfp.sy << " theta " << rfp.theta << std::endl;
+    os << "SStime " << rfp.SStime << " DStime " << rfp.DStime << " stepType " << rfp.stepType << " DeviationHipHeight " << rfp.DeviationHipHeight;
+    return os;
+  }
+
   /** Structure to store each of the ZMP value, with a given
       direction at a certain time. */
   struct ZMPPosition_s
@@ -111,6 +128,13 @@ namespace PatternGeneratorJRL
     //*(-1) if right foot stance else left foot stance
   };
   typedef struct ZMPPosition_s ZMPPosition;
+
+  inline std::ostream & operator<<(std::ostream & os, const ZMPPosition_s & zmp)
+  {
+    os << "px " << zmp.px << " py " << zmp.pz << " pz " << zmp.pz << " theta " << zmp.theta << std::endl;
+    os << "time " << zmp.time << " stepType " << zmp.stepType;
+    return os;
+  }
 
   /// Structure to store the absolute foot position.
   struct FootAbsolutePosition_t
@@ -130,6 +154,15 @@ namespace PatternGeneratorJRL
     int stepType;
   };
   typedef struct FootAbsolutePosition_t FootAbsolutePosition;
+
+  inline std::ostream & operator<<(std::ostream & os, const FootAbsolutePosition & fap)
+  {
+    os << "x " << fap.x << " y " << fap.y << " z " << fap.z << " theta " << fap.theta << " omega " << fap.omega << " omega2 " << fap.omega2 << std::endl;
+    os << "dx " << fap.dx << " dy " << fap.dy << " dz " << fap.dz << " dtheta " << fap.dtheta << " domega " << fap.domega << " domega2 " << fap.domega2 << std::endl;
+    os << "ddx " << fap.ddx << " ddy " << fap.ddy << " ddz " << fap.ddz << " ddtheta " << fap.ddtheta << " ddomega " << fap.ddomega << " ddomega2 " << fap.ddomega2 << std::endl;
+    os << "time " << fap.time << " stepType " << fap.stepType;
+    return os;
+  }
 
   // Linear constraint.
   struct LinearConstraintInequality_s
@@ -162,6 +195,13 @@ namespace PatternGeneratorJRL
   typedef struct SupportFeet_s
     SupportFeet_t;
 
+  inline std::ostream & operator<<(std::ostream & os, const SupportFeet_s & sf)
+  {
+    os << "x " << sf.x << " y " << sf.y << " theta " << sf.theta << std::endl;
+    os << " StartTime " << sf.StartTime << " SupportFoot " << sf.SupportFoot;
+    return os;
+  }
+
   /// Structure to store the absolute reference.
   struct ReferenceAbsoluteVelocity_t
   {
@@ -174,6 +214,12 @@ namespace PatternGeneratorJRL
     MAL_VECTOR(RefVectorTheta,double);
   };
   typedef struct ReferenceAbsoluteVelocity_t ReferenceAbsoluteVelocity;
+
+  inline std::ostream & operator<<(std::ostream & os, const ReferenceAbsoluteVelocity_t & rav)
+  {
+    os << "x " << rav.x << " y " << rav.y << " z " << rav.z << " dYaw " << rav.dYaw;
+    return os;
+  }
 
 }
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,8 +77,8 @@ SET(SOURCES
   PatternGeneratorInterfacePrivate.cpp
   SimplePlugin.cpp
   SimplePluginManager.cpp
+  pgtypes.cpp
   Clock.cpp
-  PGTypes.cpp
   portability/gettimeofday.cc
   privatepgtypes.cpp
   )

--- a/src/GlobalStrategyManagers/CoMAndFootOnlyStrategy.cpp
+++ b/src/GlobalStrategyManagers/CoMAndFootOnlyStrategy.cpp
@@ -145,6 +145,9 @@ int CoMAndFootOnlyStrategy::EvaluateStartingState(MAL_VECTOR(&,double) BodyAngle
   aStartingCOMState.x[0] = lStartingCOMState(0);
   aStartingCOMState.y[0] = lStartingCOMState(1);
   aStartingCOMState.z[0] = lStartingCOMState(2);
+  aStartingCOMState.yaw[0] = lStartingWaistPose(5);
+  aStartingCOMState.pitch[0] = lStartingWaistPose(4);
+  aStartingCOMState.roll[0] = lStartingWaistPose(3);
   aStartingZMPPosition= m_ComAndFootRealization->GetCOGInitialAnkles();
 
   //  cerr << "YOU SHOULD INITIALIZE PROPERLY aStartingZMPosition in   CoMAndFootOnlyStrategy::EvaluateStartingState" <<endl;

--- a/src/Mathematics/intermediate-qp-matrices.hh
+++ b/src/Mathematics/intermediate-qp-matrices.hh
@@ -125,6 +125,11 @@ namespace PatternGeneratorJRL
     inline void CoM( const com_t & CoM )
     { StateMatrices_.CoM = CoM; };
 
+    inline trunk_t const & Trunk() const
+    { return StateMatrices_.Trunk; }
+    inline void Trunk( const trunk_t & Trunk )
+    { StateMatrices_.Trunk = Trunk; }
+
     inline reference_t const & Reference() const
     { return StateMatrices_.Ref; };
     inline reference_t & Reference()

--- a/src/MotionGeneration/ComAndFootRealizationByGeometry.cpp
+++ b/src/MotionGeneration/ComAndFootRealizationByGeometry.cpp
@@ -366,13 +366,19 @@ InitializationHumanoid(MAL_VECTOR_TYPE(double) &BodyAnglesIni,
     getHumanoidDynamicRobot()->currentConfiguration();
 
   // Set to zero the free floating root.
-  CurrentConfig[0] = 0.0;
-  CurrentConfig[1] = 0.0;
-  CurrentConfig[2] = 0.0;
-
-  CurrentConfig[3] = 0.0;
-  CurrentConfig[4] = 0.0;
-  CurrentConfig[5] = 0.0;
+  if(lStartingWaistPose.size())
+  {
+    CurrentConfig[0] = lStartingWaistPose(0);
+    CurrentConfig[1] = lStartingWaistPose(1);
+    CurrentConfig[2] = lStartingWaistPose(2);
+    CurrentConfig[3] = lStartingWaistPose(3);
+    CurrentConfig[4] = lStartingWaistPose(4);
+    CurrentConfig[5] = lStartingWaistPose(5);
+  }
+  else
+  {
+    lStartingWaistPose.resize(6,0);
+  }
   
   // Initialize the configuration vector.
   for(unsigned int i=0;i<m_GlobalVRMLIDtoConfiguration.size();i++)
@@ -403,9 +409,9 @@ InitializationHumanoid(MAL_VECTOR_TYPE(double) &BodyAnglesIni,
   lStartingWaistPose(0) = CurrentConfig(0); // 0.0
   lStartingWaistPose(1) = CurrentConfig(1); // 0.0
   lStartingWaistPose(2) = CurrentConfig(2);
-  lStartingWaistPose(3) = 0.0;
-  lStartingWaistPose(4) = 0.0;
-  lStartingWaistPose(5) = 0.0;
+  lStartingWaistPose(3) = CurrentConfig(3); //0.0;
+  lStartingWaistPose(4) = CurrentConfig(4); //0.0;
+  lStartingWaistPose(5) = CurrentConfig(5); //0.0;
 
   ODEBUG("Current Config: " << CurrentConfig);
   return true;
@@ -485,9 +491,6 @@ InitializationCoM(MAL_VECTOR_TYPE(double) &BodyAnglesIni,
   /* Initialize properly the left and right initial positions of the feet. */
   memset((char *)&InitLeftFootPosition,0,sizeof(FootAbsolutePosition));
   memset((char *)&InitRightFootPosition,0,sizeof(FootAbsolutePosition));
-
-  /* Initialize the waist pose.*/
-  MAL_VECTOR_RESIZE(lStartingWaistPose,6);
 
   // Compute the forward dynamics from the configuration vector provided by the user. 
   // Initialize waist pose.

--- a/src/PatternGeneratorInterfacePrivate.cpp
+++ b/src/PatternGeneratorInterfacePrivate.cpp
@@ -541,7 +541,6 @@ namespace PatternGeneratorJRL {
     deque<RelativeFootPosition> RelativeFootPositions;
     m_ZMPVRQP->SetCurrentTime(m_InternalClock);
 
-
     m_ZMPVRQP->InitOnLine(m_ZMPPositions,
 			  m_COMBuffer,
 			  m_LeftFootPositions,
@@ -898,7 +897,6 @@ namespace PatternGeneratorJRL {
     MAL_VECTOR_TYPE(double) lCurrentConfiguration;
 
     lCurrentConfiguration = m_HumanoidDynamicRobot->currentConfiguration();
-    ODEBUG("lCurrent Configuration :" << lCurrentConfiguration);
 
 
     deque<RelativeFootPosition> lRelativeFootPositions;

--- a/src/ZMPRefTrajectoryGeneration/OrientationsPreview.cpp
+++ b/src/ZMPRefTrajectoryGeneration/OrientationsPreview.cpp
@@ -76,7 +76,6 @@ OrientationsPreview::preview_orientations(double Time,
                                           const std::deque<FootAbsolutePosition> & RightFootPositions_deq,
                                           solution_t & Solution)
 {
-
   const deque<support_state_t> & PrwSupportStates_deq = Solution.SupportStates_deq;
   std::deque<double> & PreviewedSupportAngles_deq = Solution.SupportOrientations_deq;
   std::deque<double> & PreviewedTrunkOrientations_deq = Solution.TrunkOrientations_deq;
@@ -269,7 +268,6 @@ OrientationsPreview::verify_angle_hip_joint(const support_state_t & CurrentSuppo
     double CurrentSupportFootAngle,
     unsigned StepNumber)
 {
-
   //Which limitation is relevant in the current situation?
   double uJointLimit, lJointLimit, JointLimit;
   if(CurrentSupport.Foot == LEFT)
@@ -291,7 +289,9 @@ OrientationsPreview::verify_angle_hip_joint(const support_state_t & CurrentSuppo
       return false;
     }
   else
+  {
     return true;
+  }
 }
 
 

--- a/src/ZMPRefTrajectoryGeneration/ZMPVelocityReferencedQP.cpp
+++ b/src/ZMPRefTrajectoryGeneration/ZMPVelocityReferencedQP.cpp
@@ -220,6 +220,7 @@ ZMPVelocityReferencedQP::InitOnLine(deque<ZMPPosition> & FinalZMPTraj_deq,
     COMState & lStartingCOMState,
     MAL_S3_VECTOR_TYPE(double) & lStartingZMPPosition)
 {
+  UpperTimeLimitToUpdate_ = 0.0;
 
   FootAbsolutePosition CurrentLeftFootAbsPos, CurrentRightFootAbsPos;
 

--- a/src/pgtypes.cpp
+++ b/src/pgtypes.cpp
@@ -29,9 +29,9 @@ namespace PatternGeneratorJRL
   {
     for(unsigned int i=0;i<3;i++)
       {
-	x[i] = aCS.x[i];
-	y[i] = aCS.y[i];
-	z[i] = aCS.z[i];
+        x[i] = aCS.x[i];
+        y[i] = aCS.y[i];
+        z[i] = aCS.z[i];
       };
     yaw     = aCS.yaw[0];  
     pitch   = aCS.pitch[0];
@@ -43,9 +43,9 @@ namespace PatternGeneratorJRL
   {
     for(unsigned int i=0;i<3;i++)
       {
-	x[i] = aCS.x[i];
-	y[i] = aCS.y[i];
-	z[i] = aCS.z[i];
+        x[i] = aCS.x[i];
+        y[i] = aCS.y[i];
+        z[i] = aCS.z[i];
       };
     yaw[0]   = aCS.yaw;   yaw[1]   = yaw[2]   = 0.0;
     pitch[0] = aCS.pitch; pitch[1] = pitch[2] = 0.0;
@@ -57,8 +57,8 @@ namespace PatternGeneratorJRL
   {
     for(unsigned int i=0;i<3;i++)
       { 
-	x[i] = 0.0; y[i] = 0.0;
-	yaw[i] = 0.0; pitch[i] = 0.0; roll[i] = 0.0;
+        x[i] = 0.0; y[i] = 0.0;
+        yaw[i] = 0.0; pitch[i] = 0.0; roll[i] = 0.0;
       }
   }
 

--- a/src/privatepgtypes.cpp
+++ b/src/privatepgtypes.cpp
@@ -377,4 +377,5 @@ namespace PatternGeneratorJRL
   reference_t::frame_t::frame_t(const frame_t & F):
       X(F.X), Y(F.X), Yaw(F.Yaw), X_vec(F.X_vec), Y_vec(F.Y_vec), Yaw_vec(F.Yaw_vec)
   {}
+
 }

--- a/src/privatepgtypes.hh
+++ b/src/privatepgtypes.hh
@@ -49,10 +49,36 @@ namespace PatternGeneratorJRL
     LEFT, RIGHT
   };
 
+  inline std::ostream & operator<<(std::ostream & out, const foot_type_e & ft)
+  {
+    switch(ft)
+    {
+      case LEFT:
+        out << "LEFT";
+        break;
+      default:
+        out << "RIGHT";
+    }
+    return out;
+  }
+
   enum PhaseType
   {
     SS, DS
   };
+
+  inline std::ostream & operator<<(std::ostream & out, const PhaseType & pt)
+  {
+    switch(pt)
+    {
+      case SS:
+        out << "SingleSupport";
+        break;
+      default:
+        out << "DoubleSupport";
+    }
+    return out;
+  }
 
   enum ineq_e
   {
@@ -168,6 +194,13 @@ namespace PatternGeneratorJRL
     reference_t();
     reference_t(const reference_t &);
   };
+
+  inline std::ostream & operator<<(std::ostream & out, const reference_t & Ref)
+  {
+    out << "Global: (" << Ref.Global.X << ", " << Ref.Global.Y << ", " << Ref.Global.Yaw << ")" << std::endl;
+    out << "Local: (" << Ref.Local.X << ", " << Ref.Local.Y << ", " << Ref.Local.Yaw << ")";
+    return out;
+  }
 
   /// \brief Convex hull
   struct convex_hull_t
@@ -285,6 +318,23 @@ namespace PatternGeneratorJRL
 
     support_state_t();
   };
+
+  inline std::ostream & operator<<(std::ostream & out, const support_state_t & st)
+  {
+    out << "SupportState" << std::endl;
+    out << "PhaseType " << st.Phase << std::endl;
+    out << "Foot " << st.Foot << std::endl;
+    out << "NbStepsLeft " << st.NbStepsLeft << std::endl;
+    out << "StepNumber " << st.StepNumber << std::endl;
+    out << "NbInstants " << st.NbInstants << std::endl;
+    out << "TimeLimit " << st.TimeLimit << std::endl;
+    out << "StartTime " << st.StartTime << std::endl;
+    out << "X " << st.X << std::endl;
+    out << "Y " << st.Y << std::endl;
+    out << "Yaw " << st.Yaw << std::endl;
+    out << "StateChanged " << st.StateChanged;
+    return out;
+  }
 
   /// \brief Solution
   struct solution_t


### PR DESCRIPTION
This pull request fix some issues with PG initialization.

In particular, on the current version, if you do:
robot.pg.parseCmd(":stepseq 0 0.095 0 0 -0.19 20 0 0.19 20 0 -0.19 20 0 0.19 20 0 -0.19 0 0 0.19 0");
wait for the robot to complete the movement then repeat the command, you get a discontinuity that results in erratic behaviour. Similarly, trying to start Herdt's PG after this command will fail.

This pull request fixes that on the condition that you call:
robot.pg.setInitByRealState(True);
robot.pg.initState();
